### PR TITLE
add common about info for driver compat tables

### DIFF
--- a/dbx/about-compatibility.rst
+++ b/dbx/about-compatibility.rst
@@ -7,12 +7,12 @@ remains fully operational.
 
 We maintain the following tables for each driver:
 
-- :ref:`MongoDB compatibility <mongodb-compatibility-tables-{+driver+}>`
-- :ref:`Language compatibility <language-compatibility-tables-{+driver+}>`
+- :ref:`MongoDB compatibility <mongodb-compatibility-table-about-{+driver+}>`
+- :ref:`Language compatibility <language-compatibility-table-about-{+driver+}>`
 
 Read the sections below for detailed explanations of each table.
 
-.. _mongodb-compatibility-tables-{+driver+}:
+.. _mongodb-compatibility-table-about-{+driver+}:
 
 MongoDB Compatibility Tables
 ----------------------------
@@ -44,7 +44,7 @@ appear on the chart because they are unsupported.
    Although the drivers do not advertise compatibility with the versions of
    the server released after them, they are usually interoperable.
 
-.. _language-compatibility-tables-{+driver+}:
+.. _language-compatibility-table-about-{+driver+}:
 
 Language Compatibility Tables
 -----------------------------

--- a/dbx/about-compatibility.rst
+++ b/dbx/about-compatibility.rst
@@ -1,6 +1,5 @@
-============================
-MongoDB Compatibility Tables
-============================
+About Compatibility Tables
+--------------------------
 
 We include compatibility tables for each version of the driver to guide
 your decisions on what versions you need to ensure your environment

--- a/dbx/about-compatibility.rst
+++ b/dbx/about-compatibility.rst
@@ -14,10 +14,10 @@ Read the sections below for detailed explanations of each table.
 
 .. _mongodb-compatibility-table-about-{+driver+}:
 
-MongoDB Compatibility Tables
-----------------------------
+MongoDB Compatibility Table
+---------------------------
 
-In the **MongoDB Compatibility** tables, the columns are labeled with
+In the **MongoDB Compatibility** table, the columns are labeled with
 versions of MongoDB server and the rows are labeled with major release
 versions of the driver.
 
@@ -46,10 +46,10 @@ appear on the chart because they are unsupported.
 
 .. _language-compatibility-table-about-{+driver+}:
 
-Language Compatibility Tables
------------------------------
+Language Compatibility Table
+----------------------------
 
-In the **Language Compatibility** tables, the columns are labeled with
+In the **Language Compatibility** table, the columns are labeled with
 versions of the language (e.g. Node.js, Python, etc.) and the rows are
 labeled with major release versions of the driver.
 

--- a/dbx/about-compatibility.rst
+++ b/dbx/about-compatibility.rst
@@ -1,0 +1,58 @@
+============================
+MongoDB Compatibility Tables
+============================
+
+We include compatibility tables for each version of the driver to guide
+your decisions on what versions you need to ensure your environment
+remains fully operational.
+
+We maintain the following tables for each driver:
+
+- :ref:`MongoDB compatibility <mongodb-compatibility-tables-{+driver+}>`
+- :ref:`Language compatibility <language-compatibility-tables-{+driver+}>`
+
+Read the sections below for detailed explanations of each table.
+
+.. _mongodb-compatibility-tables-{+driver+}:
+
+MongoDB Compatibility Tables
+----------------------------
+
+In the **MongoDB Compatibility** tables, the columns are labeled with
+versions of MongoDB server and the rows are labeled with major release
+versions of the driver.
+
+The check marks (✓) indicate that the driver can access **all the
+features** of that specific version of MongoDB server unless those features
+have been deprecated or removed.
+
+If you are **upgrading your server version**, your current driver should
+continue to function properly, but may not be able to access the features
+introduced in the newer server versions. We recommend using the newest
+compatible driver when upgrading your server version.
+
+If you are **upgrading your driver version**, you can use the table to
+identify which version you need to access all the newest features included
+in a specific version of the server. Also note that any of the minor
+or patch versions share the same compatibility as the major version
+release.
+
+We recommend that you avoid using older versions of the drivers that do not
+appear on the chart because they are unsupported.
+
+.. note::
+
+   Although the drivers do not advertise compatibility with the versions of
+   the server released after them, they are usually interoperable.
+
+.. _language-compatibility-tables-{+driver+}:
+
+Language Compatibility Tables
+-----------------------------
+
+In the **Language Compatibility** tables, the columns are labeled with
+versions of the language (e.g. Node.js, Python, etc.) and the rows are
+labeled with major release versions of the driver.
+
+The check marks (✓) indicate that the code in the driver is fully
+compatible with the version of the language.


### PR DESCRIPTION
This adds a shared page for use in dedicated driver projects (Node, Go, Java)