### PR TITLE
DOCSP-20271 PS Updates

### DIFF
--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -127,6 +127,24 @@
      - |checkmark|
      - |checkmark|
 
+   * - RHEL/CentOS/Oracle Linux/Rocky/Alma 9.0+
+     - x86_64
+     - Enterprise
+     - 6.0.X
+     - 
+     - 
+     - 
+     - 
+
+   * - RHEL/CentOS/Oracle Linux/Rocky/Alma 9.0+
+     - x86_64
+     - Community
+     - 6.0.X
+     - 
+     - 
+     - 
+     - 
+
    * - RHEL/CentOS/Oracle Linux/Rocky/Alma 8.0+
      - x86_64
      - Enterprise
@@ -220,18 +238,18 @@
    * - Ubuntu 22.04
      - x86_64
      - Enterprise
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
+     - 6.0.X
+     - 
+     - 
      -
      -
 
    * - Ubuntu 22.04
      - x86_64
      - Community
-     - |checkmark|
-     - |checkmark|
-     - |checkmark|
+     - 
+     - 
+     - 
      -
      -
 
@@ -454,7 +472,7 @@
    * - Amazon Linux 2022
      - arm64
      - Enterprise
-     - |checkmark|
+     - 6.0.X
      - 
      - 
      - 
@@ -463,7 +481,7 @@
    * - Amazon Linux 2022
      - arm64
      - Community
-     - |checkmark|
+     - 6.0.X
      - 
      - 
      - 
@@ -487,6 +505,24 @@
      - 4.2.13+
      -
 
+   * - RHEL/CentOS/Rocky/Alma 9
+     - arm64
+     - Enterprise
+     - 6.0.X
+     - 
+     - 
+     -
+     -
+
+   * - RHEL/CentOS/Rocky/Alma 9
+     - arm64
+     - Community
+     - 6.0.X
+     - 
+     - 
+     -
+     -
+
    * - RHEL/CentOS/Rocky/Alma 8
      - arm64
      - Enterprise
@@ -502,6 +538,24 @@
      - |checkmark|
      - |checkmark|
      - 4.4.4+
+     -
+     -
+
+   * - Ubuntu 22.04
+     - arm64
+     - Enterprise
+     - 6.0.X
+     - 
+     - 
+     -
+     -
+
+   * - Ubuntu 22.04
+     - arm64
+     - Community
+     - 6.0.X
+     - 
+     - 
      -
      -
 

--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -634,8 +634,8 @@
    * - RHEL/CentOS 7
      - ppc64le
      - Enterprise
-     - |checkmark|
-     - 
+     - 6.0.X
+     - 5.0.X
      - |checkmark| 
      - |checkmark| 
      - 4.0.0 - 4.0.27
@@ -643,7 +643,7 @@
    * - RHEL/CentOS 7
      - ppc64le
      - Community
-     -
+     - 
      - 
      - 
      - 

--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -19,6 +19,24 @@
      - 4.2      
      - 4.0      
 
+   * - Amazon Linux 2022
+     - x86_64
+     - Enterprise
+     - |checkmark|
+     - 
+     - 
+     - 
+     - 
+
+   * - Amazon Linux 2022
+     - x86_64
+     - Community
+     - 
+     - 
+     - 
+     - 
+     - 
+
    * - Amazon Linux V2
      - x86_64
      - Enterprise
@@ -198,6 +216,24 @@
      - |checkmark|
      - |checkmark|
      - |checkmark|
+
+   * - Ubuntu 22.04
+     - x86_64
+     - Enterprise
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
+
+   * - Ubuntu 22.04
+     - x86_64
+     - Community
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     -
+     -
 
    * - Ubuntu 20.04
      - x86_64
@@ -414,6 +450,24 @@
      - 
      - 
      - 
+
+   * - Amazon Linux 2022
+     - arm64
+     - Enterprise
+     - |checkmark|
+     - 
+     - 
+     - 
+     -
+
+   * - Amazon Linux 2022
+     - arm64
+     - Community
+     - |checkmark|
+     - 
+     - 
+     - 
+     -
 
    * - Amazon Linux 2
      - arm64


### PR DESCRIPTION
Description:

This docs update is currently waiting for several minor releases to land in 5.0.X or 6.0.X versions which are in the engineering backlog. I have added slots for newly supported OS's such as Amazon Linux 2022 and marked future releases with a 5.0.X or 6.0.X placeholder. When the downstream tickets are completed, these will be updated prior to merge to reflect the correct minor release for the supported architecture/OS.

[Scoping Display](https://docs.google.com/spreadsheets/d/1-sZKW70HbVt2yHOWa18qwBwi-gBcn54tWmronnn89kI/edit#gid=60516157)
