### PR TITLE
DOCS-15888 Amazon Linux 2022 Support

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "esbonio.sphinx.confDir": ""
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,1 @@
-{
-    "esbonio.sphinx.confDir": ""
-}
+{}

--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -17,7 +17,25 @@
      - 5.0     
      - 4.4      
      - 4.2      
-     - 4.0      
+     - 4.0   
+
+   * - Amazon Linux 2022
+     - x86_64
+     - Enterprise
+     - 6.2.0+
+     - 
+     - 
+     -
+     - 
+
+   * - Amazon Linux 2022
+     - x86_64
+     - Community
+     - 6.2.0+
+     - 
+     - 
+     -
+     - 
 
    * - Amazon Linux V2
      - x86_64
@@ -468,6 +486,24 @@
      - 
      - 
      - 
+
+   * - Amazon Linux 2022
+     - arm64
+     - Community
+     - 6.2.0+ 
+     -
+     -
+     -
+     -
+
+   * - Amazon Linux 2022
+     - arm64
+     - Enterprise
+     - 6.2.0+ 
+     -
+     -
+     -
+     -
 
    * - Amazon Linux 2
      - arm64

--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -489,7 +489,7 @@
 
    * - Amazon Linux 2022
      - arm64
-     - Community
+     - Enterprise
      - 6.2.0+ 
      -
      -
@@ -498,7 +498,7 @@
 
    * - Amazon Linux 2022
      - arm64
-     - Enterprise
+     - Community
      - 6.2.0+ 
      -
      -


### PR DESCRIPTION
## DESCRIPTION
Add platform support for Amazon Linux 2022 

## STAGING
https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/v6.0/installation/#supported-platforms

## JIRA
https://jira.mongodb.org/browse/DOCS-15888

## BUILD LOG
No build log because this is `docs-shared` repo