### PR TITLE
DOCSP-29005 Remove incorrect arm64 Ubuntu Platform entry

### DIFF
--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -307,24 +307,6 @@
      - |checkmark|
      - |checkmark|
 
-   * - Ubuntu 22.04
-     - arm64
-     - Enterprise
-     - 6.0.3+
-     -
-     -
-     -
-     -
-
-   * - Ubuntu 22.04
-     - arm64
-     - Community
-     - 6.0.3+
-     -
-     -
-     -
-     -
-
    * - Windows Server 2019
      - x86_64
      - Enterprise


### PR DESCRIPTION
## DESCRIPTION
Original ticket asks to update Ubuntu 22.04 arm64 entry to be compatible starting in 6.0.4, not 6.0.3. The correct entry already existed, so it looks like it was incorrectly duplicated. 

This removes the incorrect entry. Correct entry can be found on lines 526 and 535.

## STAGING 
https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/platform-support-testing/administration/production-notes/#platform-support-matrix

## JIRA
https://jira.mongodb.org/browse/DOCSP-29005