### PR TITLE
DOCSP-26903: move encrypt fields page

### DIFF
--- a/dbx/encrypt-fields.rst
+++ b/dbx/encrypt-fields.rst
@@ -33,35 +33,36 @@ In-use encryption can help prevent exposure of the following sensitive types of 
 
 MongoDB offers the following ways to encrypt fields:
 
-{+qe+}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Queryable Encryption
+~~~~~~~~~~~~~~~~~~~~
 
-{+qe+} is the next-generation in-use encryption feature,
-introduced in MongoDB 6.0 and available as a public preview. {+qe+}
-supports searching encrypted fields for equality and encrypts each value
-uniquely.
+Queryable Encryption is the next-generation in-use encryption feature,
+introduced in MongoDB Server version 6.0 and available as a public
+preview. Queryable Encryption supports searching encrypted fields for
+equality and encrypts each value uniquely.
 
-The MongoDB manual contains detailed information on the following {+qe+} topics:
+The MongoDB manual contains detailed information on the following Queryable Encryption topics:
 
-- To get started, see the :ref:`{+qe+} Quick Start <qe-quick-start>`.
-- To learn how to use {+qe+}, see the :ref:`{+qe+} Fundamentals <qe-fundamentals>`.
-- To learn how to integrate your implementation with a {+kms-long+}, see the :ref:`{+qe+} Tutorials <qe-tutorials>`.
-- To learn {+qe+} concepts, see the :ref:`{+qe+} Reference <qe-reference>`.
+- To get started, see the :ref:`Queryable Encryption Quick Start <qe-quick-start>`.
+- To learn how to use Queryable Encryption, see the :ref:`Queryable Encryption Fundamentals <qe-fundamentals>`.
+- To learn how to integrate your implementation with a Key Management System, see the :ref:`Queryable Encryption Tutorials <qe-tutorials>`.
+- To learn Queryable Encryption concepts, see the :ref:`Queryable Encryption Reference <qe-reference>`.
 
-{+csfle-long+}
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Client-side Field Level Encryption
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-{+csfle-long+} was introduced in MongoDB version v4.2 and supports searching encrypted
-fields for equality. {+csfle-short+} differs from {+qe+} in that it requires
-that the encrypted fields you want to search must be deterministically encrypted.
-When you deterministically encrypt a value, the same input value produces
-the same output value. While deterministic encryption provides greater
+Client-side Field Level Encryption (CSFLE) was introduced in MongoDB
+Server version 4.2 and supports searching encrypted fields for equality.
+CSFLE differs from Queryable Encryption in that it requires that the encrypted fields
+you want to search must be deterministically encrypted. When you
+deterministically encrypt a value, the same input value produces the
+same output value. While deterministic encryption provides greater 
 support for read operations, encrypted data with low :wikipedia:`cardinality <Cardinality>`
 is susceptible to recovery using :wikipedia:`frequency analysis <Frequency_analysis>`.
 
-The MongoDB manual contains detailed information on the following {+csfle-short+} topics:
+The MongoDB manual contains detailed information on the following CSFLE topics:
 
-- To get started, see the :ref:`{+csfle-short+} Quick Start <csfle-quick-start>`.
-- To learn how to use {+csfle-short+}, see the :ref:`{+csfle-short+} Fundamentals <csfle-fundamentals>`.
-- To learn how to integrate your {+csfle-short+} implementation with a {+kms-long+}, see the :ref:`{+csfle-short+} Tutorials <csfle-tutorials>`.
-- To learn {+csfle-short+} concepts, see the :ref:`{+csfle-short+} Reference <csfle-reference>`.
+- To get started, see the :ref:`CSFLE Quick Start <csfle-quick-start>`.
+- To learn how to use CSFLE, see the :ref:`CSFLE Fundamentals <csfle-fundamentals>`.
+- To learn how to integrate your CSFLE implementation with a Key Management System, see the :ref:`CSFLE Tutorials <csfle-tutorials>`.
+- To learn CSFLE concepts, see the :ref:`CSFLE Reference <csfle-reference>`.

--- a/dbx/encrypt-fields.rst
+++ b/dbx/encrypt-fields.rst
@@ -1,0 +1,67 @@
+==============
+Encrypt Fields
+==============
+
+.. contents:: On this page
+   :local:
+   :backlinks: none
+   :depth: 2
+   :class: singlecol
+
+Overview
+--------
+
+You can encrypt fields in a document using a set of features called
+**in-use encryption**.
+
+In-use encryption enables your client applications to encrypt data
+*before* sending it to MongoDB, and to query documents with encrypted fields.
+
+Because the driver encrypts the data before sending it to MongoDB, only
+your configured client applications can decrypt the data. Only applications
+using the driver with access to your encryption keys can access the decrypted,
+plaintext data. Should you have unauthorized access to your database, an
+attacker could only see the encrypted, ciphertext data.
+
+In-use encryption can help prevent exposure of the following sensitive types of data:
+
+- Credit card numbers
+- Addresses
+- Health information
+- Financial information
+- Any other sensitive or personally identifiable information (PII)
+
+MongoDB offers the following ways to encrypt fields:
+
+{+qe+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+{+qe+} is the next-generation in-use encryption feature,
+introduced in MongoDB 6.0 and available as a public preview. {+qe+}
+supports searching encrypted fields for equality and encrypts each value
+uniquely.
+
+The MongoDB manual contains detailed information on the following {+qe+} topics:
+
+- To get started, see the :ref:`{+qe+} Quick Start <qe-quick-start>`.
+- To learn how to use {+qe+}, see the :ref:`{+qe+} Fundamentals <qe-fundamentals>`.
+- To learn how to integrate your implementation with a {+kms-long+}, see the :ref:`{+qe+} Tutorials <qe-tutorials>`.
+- To learn {+qe+} concepts, see the :ref:`{+qe+} Reference <qe-reference>`.
+
+{+csfle-long+}
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+{+csfle-long+} was introduced in MongoDB version v4.2 and supports searching encrypted
+fields for equality. {+csfle-short+} differs from {+qe+} in that it requires
+that the encrypted fields you want to search must be deterministically encrypted.
+When you deterministically encrypt a value, the same input value produces
+the same output value. While deterministic encryption provides greater
+support for read operations, encrypted data with low :wikipedia:`cardinality <Cardinality>`
+is susceptible to recovery using :wikipedia:`frequency analysis <Frequency_analysis>`.
+
+The MongoDB manual contains detailed information on the following {+csfle-short+} topics:
+
+- To get started, see the :ref:`{+csfle-short+} Quick Start <csfle-quick-start>`.
+- To learn how to use {+csfle-short+}, see the :ref:`{+csfle-short+} Fundamentals <csfle-fundamentals>`.
+- To learn how to integrate your {+csfle-short+} implementation with a {+kms-long+}, see the :ref:`{+csfle-short+} Tutorials <csfle-tutorials>`.
+- To learn {+csfle-short+} concepts, see the :ref:`{+csfle-short+} Reference <csfle-reference>`.


### PR DESCRIPTION
JIRA - https://jira.mongodb.org/browse/DOCSP-26903

Moving [content](https://github.com/mongodb/docs-golang/blob/master/source/fundamentals/encrypt-fields.txt) from the Golang docs repo to this repo