### PR TITLE
DOCSP-29471 Remote RHEL/CentOS 7 6.0 from Support Matrix

### DIFF
--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -616,7 +616,7 @@
    * - RHEL/CentOS 7
      - ppc64le
      - Enterprise
-     - |checkmark|
+     - 
      - 
      - |checkmark| 
      - |checkmark| 


### PR DESCRIPTION
## DESCRIPTION
Removes v6.0 support for RHEL/CentOS 7 on platform support matrix. 

## STAGING 
https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/platform-support-testing/installation/#:~:text=Community-,RHEL/CentOS%207,-ppc64le

## JIRA
https://jira.mongodb.org/browse/DOCSP-29471
