### PR TITLE
DOCS-15147 Add RHEL9 ARM

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,1 +1,3 @@
-{}
+{
+    "esbonio.sphinx.confDir": ""
+}

--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -504,7 +504,25 @@
      - 4.4.4+
      - 4.2.13+
      -
-   
+
+   * - RHEL/CentOS/Rocky/Alma 9
+     - arm64
+     - Enterprise
+     - |checkmark|
+     -
+     - 
+     -
+     -
+
+   * - RHEL/CentOS/Rocky/Alma 9
+     - arm64
+     - Community
+     - |checkmark|
+     -
+     - 
+     -
+     -
+
    * - RHEL/CentOS/Rocky/Alma 8
      - arm64
      - Enterprise


### PR DESCRIPTION
## DESCRIPTION
- Add RHEL9 arm64 to platform support matrix 

## STAGING 
https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/platform-support-testing/installation/#:~:text=4.2.13%2B-,RHEL/CentOS/Rocky/Alma%209,-arm64

## JIRA 
https://jira.mongodb.org/browse/DOCS-15147