### PR TITLE
DOCSP-31054 RHEL/CentOS 7 ppc64le 6.0.7 Support

### DIFF
--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -745,7 +745,7 @@
      - ppc64le
      - Enterprise
      - 
-     - |checkmark|
+     - 6.0.7+
      - |checkmark| 
      - |checkmark| 
      - |checkmark|


### PR DESCRIPTION
## DESCRIPTION 

Notes that RHEL/CentOS 7 support is added from v6.0.7+

## STAGING 

N/A for `docs-shared` repo. 

## JIRA
https://jira.mongodb.org/browse/DOCSP-31054

## BUILD 

N/A for `docs-shared` repo. 
