### PR TITLE
DOCSP-31278 Oracle warning

### DIFF
--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -108,7 +108,7 @@
      - |checkmark|
      - |checkmark|
 
-   * - RHEL/CentOS Stream/Oracle Linux/Rocky/Alma 9.0+
+   * - Oracle Linux (Red Hat Compatible Kernel only) 9.0+
      - x86_64
      - Enterprise
      - |checkmark|
@@ -116,7 +116,7 @@
      -
      -
 
-   * - RHEL/CentOS Stream/Oracle Linux/Rocky/Alma 9.0+
+   * - Oracle Linux (Red Hat Compatible Kernel only) 9.0+
      - x86_64
      - Community
      - |checkmark|
@@ -124,7 +124,7 @@
      -
      -
    
-   * - RHEL/CentOS Stream/Oracle Linux/Rocky/Alma 8.0+
+   * - Oracle Linux (Red Hat Compatible Kernel only) 8.0+
      - x86_64
      - Enterprise
      - |checkmark|
@@ -132,7 +132,7 @@
      - |checkmark|
      - |checkmark|
 
-   * - RHEL/CentOS Stream/Oracle Linux/Rocky/Alma 8.0+
+   * - Oracle Linux (Red Hat Compatible Kernel only) 8.0+
      - x86_64
      - Community
      - |checkmark|
@@ -140,7 +140,7 @@
      - |checkmark|
      - |checkmark|
 
-   * - RHEL/CentOS/Oracle Linux 7.0+
+   * - Oracle Linux (Red Hat Compatible Kernel only) 7.0+
      - x86_64
      - Enterprise
      - |checkmark|
@@ -148,7 +148,7 @@
      - |checkmark|
      - |checkmark|
 
-   * - RHEL/CentOS/Oracle Linux 7.0+
+   * - Oracle Linux (Red Hat Compatible Kernel only) 7.0+
      - x86_64
      - Community
      - |checkmark|
@@ -156,7 +156,7 @@
      - |checkmark|
      - |checkmark|
 
-   * - RHEL/CentOS/Oracle Linux 6.2+
+   * - Oracle Linux (Red Hat Compatible Kernel only) 6.2+
      - x86_64
      - Enterprise
      -
@@ -164,7 +164,71 @@
      -
      - |checkmark|
 
-   * - RHEL/CentOS/Oracle Linux 6.2+
+   * - Oracle Linux (Red Hat Compatible Kernel only) 6.2+
+     - x86_64
+     - Community
+     -
+     -
+     -
+     - |checkmark|
+
+   * - RHEL/CentOS Stream Linux/Rocky/Alma 9.0+
+     - x86_64
+     - Enterprise
+     - |checkmark|
+     - 6.0.4+
+     -
+     -
+
+   * - RHEL/CentOS Stream Linux/Rocky/Alma 9.0+
+     - x86_64
+     - Community
+     - |checkmark|
+     - 6.0.4+
+     -
+     -
+   
+   * - RHEL/CentOS Stream Linux/Rocky/Alma 8.0+
+     - x86_64
+     - Enterprise
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - RHEL/CentOS Stream Linux/Rocky/Alma 8.0+
+     - x86_64
+     - Community
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - RHEL/CentOS Linux 7.0+
+     - x86_64
+     - Enterprise
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - RHEL/CentOS Linux 7.0+
+     - x86_64
+     - Community
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+     - |checkmark|
+
+   * - RHEL/CentOS Linux 6.2+
+     - x86_64
+     - Enterprise
+     -
+     -
+     -
+     - |checkmark|
+
+   * - RHEL/CentOS Linux 6.2+
      - x86_64
      - Community
      -


### PR DESCRIPTION
There is no way to stage shared repo builds. I used the contents of the sharedinclude to create a fake include and generate a server build instead. 


[STAGING](https://docs-mongodbcom-staging.corp.mongodb.com/docs/docsworker-xlarge/DOCSP-31278-oracle-compat-matrix-v7.0/administration/production-notes/#platform-support-matrix
)

[JIRA](https://jira.mongodb.org/browse/DOCSP-31278)


[BUILD](https://workerpool-boxgs.mongodbstitch.com/pages/job.html?collName=queue&jobId=64d0ff3f67dbe9101096364b)



[FAKE STAGING PR](https://github.com/10gen/docs-mongodb-internal/pull/4287) 


