### PR TITLE
DOCSP-34709: remove title from shared page

### DIFF
--- a/dbx/connection-troubleshooting.rst
+++ b/dbx/connection-troubleshooting.rst
@@ -1,15 +1,3 @@
-|connection-troubleshooting-anchor|
-
-==========================
-Connection Troubleshooting
-==========================
-
-.. contents:: On this page
-   :local:
-   :backlinks: none
-   :depth: 2
-   :class: singlecol
-
 This page offers potential solutions to issues that you might encounter
 when using the {+driver-long+} to connect to a MongoDB deployment.
 


### PR DESCRIPTION
Description:
Removed the title from the shared page since Snooty needs to pair it with the page anchor. While the replacement functions properly, Snooty also reports an indentation error and ambiguous reference error.