### PR TITLE
Convert Atlas CTA for driver docs into shared content

### DIFF
--- a/dbx/atlas-connect-compatible-deployment.rst
+++ b/dbx/atlas-connect-compatible-deployment.rst
@@ -1,0 +1,11 @@
+You can use the {+driver-short+} to |atlas-cta-interaction| MongoDB
+deployments running on one of the following hosted services or editions:
+
+- `MongoDB Atlas <https://www.mongodb.com/docs/atlas>`__: the fully
+  managed service for MongoDB deployments in the cloud
+- :ref:`MongoDB Enterprise <install-mdb-enterprise>`: the
+  subscription-based, self-managed version of MongoDB
+- :ref:`MongoDB Community <install-mdb-community-edition>`: the
+  source-available, free-to-use, and self-managed version of MongoDB
+
+|atlas-ui-cta|

--- a/dbx/atlas-connect-compatible-deployment.rst
+++ b/dbx/atlas-connect-compatible-deployment.rst
@@ -1,8 +1,8 @@
 You can use the {+driver-short+} to |atlas-cta-interaction| MongoDB
 deployments running on one of the following hosted services or editions:
 
-- `MongoDB Atlas <https://www.mongodb.com/docs/atlas>`__: the fully
-  managed service for MongoDB deployments in the cloud
+- :atlas:`MongoDB Atlas </>`: the fully managed service for MongoDB 
+  deployments in the cloud
 - :ref:`MongoDB Enterprise <install-mdb-enterprise>`: the
   subscription-based, self-managed version of MongoDB
 - :ref:`MongoDB Community <install-mdb-community-edition>`: the


### PR DESCRIPTION
This enables us to use consistent wording and make any necessary updates in one place for the Atlas CTA featured in select driver documentation pages.