### PR TITLE
DOCSP-41493-add-ubuntu-24-04-support

### DIFF
--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -777,3 +777,4 @@
 
 .. [#oracle-support] On Oracle Linux, MongoDB only supports the Red Hat
    Compatible Kernel.
+

--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -235,6 +235,24 @@
      - |checkmark|
      - |checkmark|
 
+   * - Ubuntu 24.04
+     - x86_64
+     - Enterprise
+     - |checkmark|
+     - 
+     - 
+     -
+     -
+
+   * - Ubuntu 24.04
+     - x86_64
+     - Community
+     - |checkmark|
+     - 
+     - 
+     -
+     -
+
    * - Ubuntu 22.04
      - x86_64
      - Enterprise
@@ -612,6 +630,24 @@
      - |checkmark|
      - |checkmark|
      - 4.4.4+
+
+   * - Ubuntu 24.04
+     - arm64
+     - Enterprise
+     - |checkmark|
+     - 
+     - 
+     -
+     -
+
+   * - Ubuntu 24.04
+     - arm64
+     - Community
+     - |checkmark|
+     - 
+     - 
+     -
+     -
 
    * - Ubuntu 22.04
      - arm64

--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -777,4 +777,3 @@
 
 .. [#oracle-support] On Oracle Linux, MongoDB only supports the Red Hat
    Compatible Kernel.
-


### PR DESCRIPTION
- Adding `Ubuntu 24.04` to PS matrix

Note- Builds not enabled for this repo, no build log available. See staged changes here: https://github.com/10gen/docs-mongodb-internal/pull/8404


https://jira.mongodb.org/browse/DOCSP-41493
