### PR TITLE
DOCSP-38877-macOS-14-support

### DIFF
--- a/server/platform-support/platform-support.rst
+++ b/server/platform-support/platform-support.rst
@@ -397,6 +397,22 @@
      - |checkmark|
      - |checkmark|
 
+   * - macOS14
+     - x86_64 
+     - Enterprise
+     - |checkmark|
+     -
+     -
+     -
+     -
+   * - macOS14
+     - x86_64 
+     - Community
+     - |checkmark|
+     -
+     -
+     -
+     -
    * - macOS 13
      - x86_64 
      - Enterprise 
@@ -505,6 +521,24 @@
      -
      - |checkmark|
 
+   * - macOS 14
+     - arm64 
+     - Enterprise 
+     - |checkmark|
+     -
+     - 
+     - 
+     -
+
+   * - macOS 14
+     - arm64 
+     - Community 
+     - |checkmark|
+     -
+     - 
+     - 
+     - 
+   
    * - macOS 13
      - arm64 
      - Enterprise 


### PR DESCRIPTION
## Description

Update the platform support matrix for macOS 14 support. Support information sourced from the [Platform Roadmap Spreadsheet](https://docs.google.com/spreadsheets/d/1-sZKW70HbVt2yHOWa18qwBwi-gBcn54tWmronnn89kI/edit?gid=1790519872#gid=1790519872).

## Staged

See the rendered rst version of the support matrix: https://github.com/10gen/docs-shared/blob/ebfb60c1f5e1cb36fab1bd37b989da56e041983b/server/platform-support/platform-support.rst