### PR TITLE
DOCSP-38279: graalvm metadata

### DIFF
--- a/dbx/jvm/v5.2-wn-items.rst
+++ b/dbx/jvm/v5.2-wn-items.rst
@@ -19,9 +19,9 @@
   servers are available.
 
 - Adds reachability metadata needed when your application uses GraalVM
-  Native Image. You can use this metadata to save the effort of
+  Native Image. You can use this metadata instead of
   collecting reachability metadata needed when using the driver
-  libraries. To learn more, see `Reachability Metadata
+  libraries yourself. To learn more, see `Reachability Metadata
   <https://www.graalvm.org/latest/reference-manual/native-image/metadata/>`__
   in the GraalVM documentation.
 

--- a/dbx/jvm/v5.2-wn-items.rst
+++ b/dbx/jvm/v5.2-wn-items.rst
@@ -19,17 +19,17 @@
   servers are available.
 
 - Adds reachability metadata needed when your application uses GraalVM
-  Native Image. You can use this metadata instead of
-  collecting reachability metadata needed when using the driver
-  libraries yourself. To learn more, see `Reachability Metadata
+  Native Image. This metadata replaces the need for collecting
+  reachability metadata when using the driver libraries. To learn more,
+  see `Reachability Metadata
   <https://www.graalvm.org/latest/reference-manual/native-image/metadata/>`__
   in the GraalVM documentation.
 
-  This change does not add ``libjnidispatch`` and ``libmongocrypt``
-  resource entries, because adding specify entries for all supported
+  This change does not add the ``libjnidispatch`` and ``libmongocrypt``
+  resource entries, because adding entries for all supported
   platforms (targets) significantly affects the size of
   native executables built using GraalVM Native Image. View this sample
   `resource-config.json
   <https://github.com/mongodb/mongo-java-driver/blob/master/graalvm-native-image-app/src/main/resources/META-INF/native-image/resource-config.json>`__
-  file in the JVM driver GitHub to see how to specify these entries explicitly
+  file in the driver GitHub repository to see how to specify these entries explicitly
   if your application depends on the ``org.mongodb:mongodb-crypt`` library.

--- a/dbx/jvm/v5.2-wn-items.rst
+++ b/dbx/jvm/v5.2-wn-items.rst
@@ -16,4 +16,20 @@
 
 - When a sharded cluster operation is unsuccessful, the driver avoids selecting
   the same ``mongos`` server for operation retry attempts if other ``mongos``
-  servers are available.  
+  servers are available.
+
+- Adds reachability metadata needed when your application uses GraalVM
+  Native Image. You can use this metadata to save the effort of
+  collecting reachability metadata needed when using the driver
+  libraries. To learn more, see `Reachability Metadata
+  <https://www.graalvm.org/latest/reference-manual/native-image/metadata/>`__
+  in the GraalVM documentation.
+
+  This change does not add ``libjnidispatch`` and ``libmongocrypt``
+  resource entries, because adding specify entries for all supported
+  platforms (targets) significantly affects the size of
+  native executables built using GraalVM Native Image. View this sample
+  `resource-config.json
+  <https://github.com/mongodb/mongo-java-driver/blob/master/graalvm-native-image-app/src/main/resources/META-INF/native-image/resource-config.json>`__
+  file in the JVM driver GitHub to see how to specify these entries explicitly
+  if your application depends on the ``org.mongodb:mongodb-crypt`` library.


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-38279

Adds an entry for JVM v5.2 release. will be included in the whats new pages for all 5 drivers. 