### PR TITLE
DOCSP-43906: crypto versioning revision

### DIFF
--- a/dbx/encrypt-fields.rst
+++ b/dbx/encrypt-fields.rst
@@ -16,6 +16,8 @@ set of features called **in-use encryption**. In-use encryption allows
 your application to encrypt data *before* sending it to MongoDB
 and query documents with encrypted fields.
 
+|driver-specific-content|
+
 In-use encryption prevents unauthorized users from viewing plaintext
 data as it is sent to MongoDB or while it is in an encrypted database. To
 enable in-use encryption in an application and authorize it to decrypt

--- a/dbx/jvm/v5.2-wn-items.rst
+++ b/dbx/jvm/v5.2-wn-items.rst
@@ -9,6 +9,13 @@
   can use a configured FIPS-compliant JCA provider to provide a higher
   level of security.
 
+- Revises the ``mongodb-crypt`` dependency versioning to match the
+  versioning for the JVM drivers. Future versions of ``mongodb-crypt``
+  will be released alongside the driver and will share the same
+  version number. You must upgrade your ``mongodb-crypt`` dependency to
+  v5.2.0 when upgrading your driver for this release. To learn more, see
+  |encrypt-link|.
+
 - Performance improvements due to implementation of native cryptography
   on all supported platforms. The following list describes the actions
   needed to implement this improvement depending on your operating

--- a/dbx/jvm/v5.2-wn-items.rst
+++ b/dbx/jvm/v5.2-wn-items.rst
@@ -9,12 +9,13 @@
   can use a configured FIPS-compliant JCA provider to provide a higher
   level of security.
 
-- Revises the ``mongodb-crypt`` dependency versioning to match the
-  versioning for the JVM drivers. Future versions of ``mongodb-crypt``
-  will be released alongside the driver and will share the same
-  version number. You must upgrade your ``mongodb-crypt`` dependency to
-  v5.2.0 when upgrading your driver for this release. To learn more, see
-  |encrypt-link|.
+- Revises the `mongodb-crypt
+  <https://mvnrepository.com/artifact/org.mongodb/mongodb-crypt>`__
+  dependency versioning to match the versioning for the JVM drivers.
+  Future versions of ``mongodb-crypt`` will be released alongside the
+  driver and will share the same version number. You must upgrade your
+  ``mongodb-crypt`` dependency to v5.2.0 when upgrading your driver for
+  this release. To learn more, see |encrypt-link|.
 
 - Performance improvements due to implementation of native cryptography
   on all supported platforms. The following list describes the actions


### PR DESCRIPTION
https://jira.mongodb.org/browse/DOCSP-43906

next steps:

add the link to whats new and driver content to the JVM drivers pages to describe the version of `mongodb-crypt` needed for that driver version.