### PR TITLE
DOCSP-50341 Unable to reauthenticate via OIDC fix

### DIFF
--- a/dbx/jvm/v5..5.1-wn-items.rst
+++ b/dbx/jvm/v5..5.1-wn-items.rst
@@ -1,2 +1,2 @@
 - Fixes an issue where OIDC reauthentication failed when triggered by an operation 
-  executed in a session, including operations executed in a transaction.
+  run in a session, including operations run in a transaction.


### PR DESCRIPTION
[DOCSP-50341](https://jira.mongodb.org/browse/DOCSP-50341)
Will be added to the release notes for JVM drivers for v5.5.1