### PR TITLE
(DOCSP-45160) Replace a replacement for Serverless with Flex, no content changes

### DIFF
--- a/cet/atlas/data-processing.rst
+++ b/cet/atlas/data-processing.rst
@@ -131,8 +131,6 @@ Examples of services and features for which Atlas does not regionalize data proc
     feature is configured, logs are pushed directly from {+service+}
     {+clusters+} to the customer's S3 bucket without traversing the {+service+} control plane
 
-- Data Explorer and Performance Advisor for :ref:`Flex clusters <ref-deployment-types>`
-
 
 Examples of data that are **not** covered by a non-US 
 *Project Services Region*, i.e., that cannot be regionalized, include: 

--- a/cet/atlas/data-processing.rst
+++ b/cet/atlas/data-processing.rst
@@ -131,7 +131,7 @@ Examples of services and features for which Atlas does not regionalize data proc
     feature is configured, logs are pushed directly from {+service+}
     {+clusters+} to the customer's S3 bucket without traversing the {+service+} control plane
 
-- Data Explorer and Performance Advisor for :ref:`{+Serverless-instances+} <ref-deployment-types>`
+- Data Explorer and Performance Advisor for :ref:`Flex clusters <ref-deployment-types>`
 
 
 Examples of data that are **not** covered by a non-US 


### PR DESCRIPTION
Serverless instances are removed fully. This doc mentions them. Serverless are replaced by Flex. 
I changed one reference. 
This change is needed because [this PR](https://github.com/10gen/docs-mongodb-internal/pull/13283) removed a replacement {+Serverless-instances+} that this file was using. 
I can't add Anurag as a reviewer for this repo. 
I can:
remove this sentence altogether, as serverless are not supported anymore. 
replace serverless with Flex if that's approved (I am not aware of any limitations in this area, but we should confirm.
What do you suggest?
Note: this change is needed ONLY because it breaks the build for the linked PR. 
Thank you.
