### PR TITLE
(DOCSP-58943) Create shared-include for Shared Responsibility Model website launch

### DIFF
--- a/cet/atlas/shared-responsibility-model-intro.rst
+++ b/cet/atlas/shared-responsibility-model-intro.rst
@@ -1,0 +1,7 @@
+The |service-fullname| |shared-rm| defines the complementary duties of MongoDB 
+and its customers in maintaining a secure and resilient data environment. 
+Under this framework, MongoDB manages the security and operational integrity 
+of the underlying platform, while customers are responsible for the 
+configuration, management, and data policies of their specific deployments. 
+For a detailed breakdown of ownership across security and operational excellence, 
+see `Shared Responsibility Model <https://www.mongodb.com/resources/products/fundamentals/shared-responsibility>`__.


### PR DESCRIPTION
[DOCSP-58934](https://jira.mongodb.org/browse/DOCSP-58934) Add links to new Shared Responsibility Model webpage
This PR creates a shared include for an intro paragraph to Shared Responsibility Model that will be used in the monorepo in multiple files across docs directories in Atlas, AAC, and others. 

## Changes made
- Create include as plain text paragraph, verbatim from Legal approved text. 
- Add link to new website URL for Shared Responsibility Model page

## Staging preview
- Staging is only possible on the monorepo related PR. 