### PR TITLE
DOCSP-59683: Fix literalinclude paths in C# aggregation RST files

### DIFF
--- a/dbx/csharp/aggregation/rst-files/bucket.rst
+++ b/dbx/csharp/aggregation/rst-files/bucket.rst
@@ -20,7 +20,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :language: csharp
    :dedent: 8
    :start-after: // start bucket
@@ -33,7 +33,7 @@ The following example performs the same ``$bucket`` operation as the previous ex
 but groups all documents with a ``Runtime`` value greater than ``999`` into the
 default bucket, named ``"Other"``:
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start bucketOptions
    :end-before: // end bucketOptions
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/bucketAuto.rst
+++ b/dbx/csharp/aggregation/rst-files/bucketAuto.rst
@@ -20,7 +20,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start bucketAuto
    :end-before: // end bucketAuto
    :language: csharp
@@ -32,7 +32,7 @@ object to specify a :wikipedia:`preferred number <Preferred_number>`
 The following example performs the same ``$bucketAuto`` operation as the previous
 example, but also sets the bucket boundaries at powers of 2:
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start bucketAutoOptions
    :end-before: // end bucketAutoOptions
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/changeStream.rst
+++ b/dbx/csharp/aggregation/rst-files/changeStream.rst
@@ -17,7 +17,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start changeStream
    :end-before: // end changeStream
    :language: csharp
@@ -33,7 +33,7 @@ example, but specifies the following options:
 - The ``StartAtOperationTime`` option specifies the logical starting point for the
   change stream.
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start changeStreamOptions
    :end-before: // end changeStreamOptions
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/changeStreamSplitLargeEvent.rst
+++ b/dbx/csharp/aggregation/rst-files/changeStreamSplitLargeEvent.rst
@@ -20,7 +20,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start changeStreamSplitLargeEvent
    :end-before: // end changeStreamSplitLargeEvent
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/count.rst
+++ b/dbx/csharp/aggregation/rst-files/count.rst
@@ -20,7 +20,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start count
    :end-before: // end count
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/densify.rst
+++ b/dbx/csharp/aggregation/rst-files/densify.rst
@@ -30,7 +30,7 @@ which contain measurements for the same ``position`` field, one hour apart:
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start densify
    :end-before: // end densify
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/documents.rst
+++ b/dbx/csharp/aggregation/rst-files/documents.rst
@@ -17,7 +17,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start documents
    :end-before: // end documents
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/facet.rst
+++ b/dbx/csharp/aggregation/rst-files/facet.rst
@@ -22,7 +22,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start facet
    :end-before: // end facet
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/geoNear.rst
+++ b/dbx/csharp/aggregation/rst-files/geoNear.rst
@@ -30,7 +30,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start geoNear
    :end-before: // end geoNear
    :language: csharp
@@ -47,7 +47,7 @@ parameter that only matches documents in which the value of the
 the calculated distance in the ``distance`` field of the output
 documents.
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start geoNear min
    :end-before: // end geoNear min
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/graphLookup.rst
+++ b/dbx/csharp/aggregation/rst-files/graphLookup.rst
@@ -12,7 +12,7 @@ A collection named ``employees`` has the following documents:
 
 The following ``Employee`` class models documents in the ``employees`` collection:
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/Employee.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/Employee.cs
    :language: csharp
 
 .. sharedinclude:: dbx/csharp/aggregation/method-intro.rst
@@ -34,7 +34,7 @@ The following ``Employee`` class models documents in the ``employees`` collectio
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start graphLookupBasic
    :end-before: // end graphLookupBasic
    :language: csharp
@@ -45,7 +45,7 @@ object to specify the depth to recurse and name of the depth field. The followin
 code example performs the same ``$graphLookup`` operation as the previous example,
 but specifies a maximum recursion depth of ``1``:
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start graphLookupDepth
    :end-before: // end graphLookupDepth
    :language: csharp
@@ -56,7 +56,7 @@ must match in order for MongoDB to include them in your search. The following co
 example performs the same ``$graphLookup`` operation as the previous examples, but
 includes only ``Employee`` documents where the ``Hobbies`` field contains ``"golf"``:
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start graphLookupMatch
    :end-before: // end graphLookupMatch
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/group.rst
+++ b/dbx/csharp/aggregation/rst-files/group.rst
@@ -23,7 +23,7 @@
       
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start group
    :end-before: // end group
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/limit.rst
+++ b/dbx/csharp/aggregation/rst-files/limit.rst
@@ -17,7 +17,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start limit
    :end-before: // end limit
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/lookup.rst
+++ b/dbx/csharp/aggregation/rst-files/lookup.rst
@@ -4,7 +4,7 @@
 The following ``Comment`` class models the documents in the ``sample_mflix.comments``
 collection:
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/Comment.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/Comment.cs
    :language: csharp
 
 .. sharedinclude:: dbx/csharp/aggregation/method-intro.rst
@@ -28,7 +28,7 @@ collection:
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start lookup
    :end-before: // end lookup
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/match.rst
+++ b/dbx/csharp/aggregation/rst-files/match.rst
@@ -20,7 +20,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start match
    :end-before: // end match
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/merge.rst
+++ b/dbx/csharp/aggregation/rst-files/merge.rst
@@ -35,7 +35,7 @@
         not match a document in the ``movies`` collection, it should be inserted into the
         ``movies`` collection.
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start merge
    :end-before: // end merge
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/out.rst
+++ b/dbx/csharp/aggregation/rst-files/out.rst
@@ -19,7 +19,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start out
    :end-before: // end out
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/projection/sample-data-movie.rst
+++ b/dbx/csharp/aggregation/rst-files/projection/sample-data-movie.rst
@@ -10,7 +10,7 @@ The following ``Movie`` and ``ImdbData`` classes model the documents in the
 .. literalinclude:: /dbx/csharp/aggregation/code/projection/Movie.cs
    :language: csharp
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/ImdbData.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/ImdbData.cs
    :language: csharp
 
 .. sharedinclude:: dbx/csharp/aggregation/convention-pack-note.rst

--- a/dbx/csharp/aggregation/rst-files/replaceRoot.rst
+++ b/dbx/csharp/aggregation/rst-files/replaceRoot.rst
@@ -3,7 +3,7 @@
 
 The following class models ``ImdbData`` documents:
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/ImdbData.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/ImdbData.cs
    :language: csharp
 
 .. sharedinclude:: dbx/csharp/aggregation/method-intro.rst
@@ -25,7 +25,7 @@ The following class models ``ImdbData`` documents:
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start replaceRoot
    :end-before: // end replaceRoot
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/replaceWith.rst
+++ b/dbx/csharp/aggregation/rst-files/replaceWith.rst
@@ -3,7 +3,7 @@
 
 The following class models ``ImdbData`` documents:
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/ImdbData.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/ImdbData.cs
    :language: csharp
 
 .. sharedinclude:: dbx/csharp/aggregation/method-intro.rst
@@ -25,7 +25,7 @@ The following class models ``ImdbData`` documents:
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start replaceWith
    :end-before: // end replaceWith
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/sample-data-movie.rst
+++ b/dbx/csharp/aggregation/rst-files/sample-data-movie.rst
@@ -7,7 +7,7 @@ Driver documentation.
 The following ``Movie`` class models the documents in the ``sample_mflix.movies``
 collection:
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/Movie.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/Movie.cs
    :language: csharp
 
 .. sharedinclude:: dbx/csharp/aggregation/convention-pack-note.rst

--- a/dbx/csharp/aggregation/rst-files/sample-data-theaters.rst
+++ b/dbx/csharp/aggregation/rst-files/sample-data-theaters.rst
@@ -7,5 +7,5 @@ Driver documentation.
 The following ``Theater``, ``Location``, and ``Address`` classes model
 the documents in the ``sample_mflix.theaters`` collection:
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/Theater.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/Theater.cs
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/sample-data-weather.rst
+++ b/dbx/csharp/aggregation/rst-files/sample-data-weather.rst
@@ -7,5 +7,5 @@ Driver documentation.
 The following ``Weather`` and ``Point`` classes model the documents in the
 ``sample_weatherdata.data`` collection:
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/Weather.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/Weather.cs
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/sample.rst
+++ b/dbx/csharp/aggregation/rst-files/sample.rst
@@ -17,7 +17,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start sample
    :end-before: // end sample
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/set.rst
+++ b/dbx/csharp/aggregation/rst-files/set.rst
@@ -20,7 +20,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start set
    :end-before: // end set
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/setWindowFields.rst
+++ b/dbx/csharp/aggregation/rst-files/setWindowFields.rst
@@ -2,7 +2,7 @@
 The following ``WeatherMeasurement`` class represents documents in a collection
 of weather measurements:
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/WeatherMeasurement.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/WeatherMeasurement.cs
    :language: csharp
 
 .. sharedinclude:: dbx/csharp/aggregation/method-intro.rst
@@ -25,7 +25,7 @@ of weather measurements:
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start setWindowFields
    :end-before: // end setWindowFields
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/skip.rst
+++ b/dbx/csharp/aggregation/rst-files/skip.rst
@@ -18,7 +18,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start skip
    :end-before: // end skip
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/sort.rst
+++ b/dbx/csharp/aggregation/rst-files/sort.rst
@@ -20,7 +20,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start sort
    :end-before: // end sort
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/sortByCount.rst
+++ b/dbx/csharp/aggregation/rst-files/sortByCount.rst
@@ -20,7 +20,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start sortByCount
    :end-before: // end sortByCount
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/unionWith.rst
+++ b/dbx/csharp/aggregation/rst-files/unionWith.rst
@@ -20,7 +20,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start unionWith
    :end-before: // end unionWith
    :language: csharp

--- a/dbx/csharp/aggregation/rst-files/unwind.rst
+++ b/dbx/csharp/aggregation/rst-files/unwind.rst
@@ -21,7 +21,7 @@
 
    .. replacement:: more-method-description
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start unwind
    :end-before: // end unwind
    :language: csharp
@@ -38,7 +38,7 @@ example, but also includes the following options:
   document. The value of this field is the array index of the ``Genres`` field's value
   in the input document's ``Genres`` array.
 
-.. literalinclude:: /dbx/csharp/aggregation/code/aggregation/BuildersExamples.cs
+.. literalinclude:: /dbx/csharp/aggregation/code/BuildersExamples.cs
    :start-after: // start unwindPreserve
    :end-before: // end unwindPreserve
    :language: csharp


### PR DESCRIPTION
## Summary

Fixes broken `literalinclude` paths in all C# aggregation stage RST files under `dbx/csharp/aggregation/rst-files/`.

All 29 RST files referenced code files as `code/aggregation/<file>.cs`, but the files live at `code/<file>.cs` (no `aggregation/` subdirectory). This caused all code examples to silently fail to render on any page using these sharedinclude files.

## Changes

- Removed the spurious `aggregation/` segment from every `literalinclude` path across all affected RST files (29 files total)

## JIRA

[DOCSP-59683](https://jira.mongodb.org/browse/DOCSP-59683)