### PR TITLE
DOCSP-59937 Java v5.7 Release Notes

### DIFF
--- a/dbx/jvm/v5.7-wn-items.rst
+++ b/dbx/jvm/v5.7-wn-items.rst
@@ -5,3 +5,5 @@
 - Fixes parsing error of ``JSONPrimitive`` numbers, where scientifically formatted numbers 
   were parsed as plain Ints or Longs.
 - Improves Micrometer observability integration.
+- Simplifies ``ServerMonitor`` thread names and removes the
+  ``=`` character, which some monitoring systems cannot process.

--- a/dbx/jvm/v5.7-wn-items.rst
+++ b/dbx/jvm/v5.7-wn-items.rst
@@ -1,8 +1,8 @@
 .. important:: 
 
-    The minimum supported MongoDB Server version will raise from 
-    4.2 to 4.4 in a future release. We recommend upgrading to the latest MongoDB 
-    Server version to take advantage of the latest features and improvements 
+    The next minor release will drop support for MongoDB Server version 4.2 and 
+    raise the minimum supported version to 4.4. We recommend upgrading to the latest 
+    MongoDB Server version to take advantage of the latest features and improvements 
     in the driver. See the :manual:`Release Notes </release-notes/>` section 
     in the Server manual to learn more about upgrading.
 

--- a/dbx/jvm/v5.7-wn-items.rst
+++ b/dbx/jvm/v5.7-wn-items.rst
@@ -1,8 +1,16 @@
-- Upgrades ``libcrypt`` to 1.17.3
-- Uses ``ZstdInputStreamNoFinalizer`` for Zstandard decompression
-- Releases connection between empty ``getMore`` responses in ``AsyncCommandCursor``
-- Adds stack-safe async loop support with trampoline pattern to prevent stack overflow errors
-- Fixes parsing error of ``JSONPrimitive`` numbers, where scientifically formatted numbers 
+.. important:: 
+
+    The minimum supported MongoDB Server version will raise from 
+    4.2 to 4.4 in a future release. We recommend upgrading to the latest MongoDB 
+    Server version to take advantage of the latest features and improvements 
+    in the driver. See the :manual:`Release Notes </release-notes/>` section 
+    in the Server manual to learn more about upgrading.
+
+- Upgrades ``libcrypt`` to 1.17.3.
+- Uses ``ZstdInputStreamNoFinalizer`` for Zstandard decompression.
+- Releases connection between empty ``getMore`` responses in ``AsyncCommandCursor``.
+- Adds stack-safe async loop support with trampoline pattern to prevent stack overflow errors.
+- Fixes parsing error of ``JSONPrimitive`` numbers, where scientifically formatted numbers. 
   were parsed as plain Ints or Longs.
 - Improves Micrometer observability integration.
 - Simplifies ``ServerMonitor`` thread names and removes the

--- a/dbx/jvm/v5.7-wn-items.rst
+++ b/dbx/jvm/v5.7-wn-items.rst
@@ -1,0 +1,7 @@
+- Upgrades ``libcrypt`` to 1.17.3
+- Uses ``ZstdInputStreamNoFinalizer`` for Zstandard decompression
+- Releases connection between empty ``getMore`` responses in ``AsyncCommandCursor``
+- Adds stack-safe async loop support with trampoline pattern to prevent stack overflow errors
+- Fixes parsing error of ``JSONPrimitive`` numbers, where scientifically formatted numbers 
+  were parsed as plain Ints or Longs.
+- Improves Micrometer observability integration.

--- a/dbx/jvm/v5.7-wn-items.rst
+++ b/dbx/jvm/v5.7-wn-items.rst
@@ -10,7 +10,7 @@
 - Uses ``ZstdInputStreamNoFinalizer`` for Zstandard decompression.
 - Releases connection between empty ``getMore`` responses in ``AsyncCommandCursor``.
 - Adds stack-safe async loop support with trampoline pattern to prevent stack overflow errors.
-- Fixes parsing error of ``JSONPrimitive`` numbers, where scientifically formatted numbers. 
+- Fixes parsing error of ``JSONPrimitive`` numbers, where scientifically formatted numbers 
   were parsed as plain Ints or Longs.
 - Improves Micrometer observability integration.
 - Simplifies ``ServerMonitor`` thread names and removes the


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/DOCSP-59937

Adds shared release notes for JVM drivers for Java v5.7. I will make a separate PR to add notes concerning the individual drivers.

No staging link available for this repo.