### PR TITLE
DOCSP-60630: Java 5.8 what's new

### DIFF
--- a/dbx/jvm/v5.7-wn-items.rst
+++ b/dbx/jvm/v5.7-wn-items.rst
@@ -1,7 +1,7 @@
-- :red:`Important:` The next minor release will drop support for MongoDB
+- :red:`Important:` An upcoming minor release will drop support for MongoDB
   Server version 4.2 and raise the minimum supported version to 4.4.
   This change aligns with the :website:`MongoDB Software Lifecycle Schedules
-  <legal/support-policy/lifecycles>`.
+  </legal/support-policy/lifecycles>`.
   
   We recommend making changes to your application to accommodate breaking changes.
   To learn more about upgrading your server version, see the :manual:`Release Notes </release-notes/>`

--- a/dbx/jvm/v5.8-wn-items.rst
+++ b/dbx/jvm/v5.8-wn-items.rst
@@ -1,7 +1,7 @@
 - Adds a typed builder API for vector search index definitions.
 
 - Adds support for the ``$rerank`` aggregation stage. When connected to an Atlas cluster running
-  on MongoDB 8.3 or later, you can use the ``Aggregates.rerank()`` builder method to create this stage.
+  MongoDB 8.3 or later, you can use the ``Aggregates.rerank()`` builder method to create this stage.
 
 - Adds support for the ``vectorSearch`` operator in a ``$search`` pipeline stage. You can
   use the ``SearchOperator.vectorSearch()`` builder method to perform approximate nearest neighbor

--- a/dbx/jvm/v5.8-wn-items.rst
+++ b/dbx/jvm/v5.8-wn-items.rst
@@ -21,7 +21,7 @@
 - Fixes an OSGi bundle resolution failure when Micrometer is
   not present.
 
-- Adds missing Javadoc to ``MongodbObservation`` and
-  ``MongodbObservationContext``.
+- Adds Javadoc documentation to the ``MongodbObservation`` and
+  ``MongodbObservationContext`` classes.
 
-- Upgrades ``libmongocrypt`` to 1.18.1.
+- Upgrades the ``libmongocrypt`` version to 1.18.1.

--- a/dbx/jvm/v5.8-wn-items.rst
+++ b/dbx/jvm/v5.8-wn-items.rst
@@ -1,0 +1,27 @@
+- Adds a typed builder API for vector search index definitions.
+
+- Adds support for the ``$rerank`` aggregation stage. When connected to an Atlas cluster running
+  on MongoDB 8.3 or later, you can use the ``Aggregates.rerank()`` builder method to create this stage.
+
+- Adds support for the ``vectorSearch`` operator in a ``$search`` pipeline stage. You can
+  use the ``SearchOperator.vectorSearch()`` builder method to perform approximate nearest neighbor
+  (ANN) vector search, or ``SearchOperator.vectorSearchExact()`` for exact nearest neighbor
+  (ENN) search. The returned ``VectorSearchOperator`` supports a ``filter()`` method to apply
+  lexical prefilters.
+
+- Adds support for configuring stored source on vector search index definitions
+  by using the ``storedSource()`` method in the ``VectorSearchIndexDefinition`` class.
+
+- Adds support for requesting stored source fields in ``$vectorSearch`` results by using the
+  ``returnStoredSource()`` method in the ``VectorSearchOptions`` class.
+
+- Optimizes ``RawBsonDocument`` encode and decode performance by
+  eliminating intermediate allocations.
+
+- Fixes an OSGi bundle resolution failure when Micrometer is
+  not present.
+
+- Adds missing Javadoc to ``MongodbObservation`` and
+  ``MongodbObservationContext``.
+
+- Upgrades ``libmongocrypt`` to 1.18.1.


### PR DESCRIPTION
JIRA - https://jira.mongodb.org/browse/DOCSP-60630

Shared what's new for JVM 5.8. Added to the docs in https://github.com/10gen/docs-mongodb-internal/pull/20721.