### PR TITLE
[drivers] add shared include for localThresholdMS latency window

### DIFF
--- a/dbx/local-threshold-ms.rst
+++ b/dbx/local-threshold-ms.rst
@@ -2,10 +2,11 @@ When connecting to a replica set with a non-primary read preference,
 the driver reads from the nearest eligible replica set member within
 the latency window. When connecting to a sharded cluster, the driver
 selects from all reachable ``mongos`` instances within the latency
-window.
+window. To learn about read preference modes, see :manual:`Read
+Preference </core/read-preference/>`.
 
 By default, the driver uses only those servers whose ping times are
-within 15 milliseconds of the nearest server.
+within 15 milliseconds of the nearest eligible server.
 
 For example, suppose your replica set has five members and the
 nearest member has a ping time of 5 milliseconds. With the default

--- a/dbx/local-threshold-ms.rst
+++ b/dbx/local-threshold-ms.rst
@@ -11,7 +11,8 @@ within 15 milliseconds of the nearest eligible server.
 For example, suppose your replica set has five members and the
 nearest member has a ping time of 5 milliseconds. With the default
 ``localThresholdMS`` of 15 milliseconds, only members with a ping
-time of 20 milliseconds or less are within the latency window:
+time of 20 milliseconds or less are within the latency window, as
+shown in the following table:
 
 .. list-table::
    :header-rows: 1

--- a/dbx/local-threshold-ms.rst
+++ b/dbx/local-threshold-ms.rst
@@ -1,0 +1,42 @@
+When connecting to a replica set with a non-primary read preference,
+the driver reads from the nearest eligible replica set member within
+the latency window. When connecting to a sharded cluster, the driver
+selects from all reachable ``mongos`` instances within the latency
+window.
+
+By default, the driver uses only those servers whose ping times are
+within 15 milliseconds of the nearest server.
+
+For example, suppose your replica set has five members and the
+nearest member has a ping time of 5 milliseconds. With the default
+``localThresholdMS`` of 15 milliseconds, only members with a ping
+time of 20 milliseconds or less are within the latency window:
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 25 25
+
+   * - Host
+     - Type
+     - Ping Time
+     - Within Latency Window
+   * - ``host1``
+     - Primary
+     - 5ms
+     - Yes
+   * - ``host2``
+     - Secondary
+     - 9ms
+     - Yes
+   * - ``host3``
+     - Secondary
+     - 13ms
+     - Yes
+   * - ``host4``
+     - Secondary
+     - 24ms
+     - No
+   * - ``host5``
+     - Secondary
+     - 42ms
+     - No


### PR DESCRIPTION
Adds `dbx/local-threshold-ms.rst`, a driver-agnostic shared include covering the latency window explanation and example table for the `localThresholdMS` setting.

Used by: DOCSP-59080 (https://github.com/10gen/docs-mongodb-internal/pull/20416)