### PR TITLE
DOCSP-61752: Add JVM v5.9 what's new items

### DIFF
--- a/dbx/jvm/v5.9-wn-items.rst
+++ b/dbx/jvm/v5.9-wn-items.rst
@@ -3,11 +3,14 @@
   on MongoDB 9.0 and later. To learn more about QE, see |encrypt-link|.
 
 - Renames the explicit encryption API for QE string queries from
-  ``Text`` to ``String``. The new ``StringOptions`` class and the
-  ``EncryptOptions.stringOptions()`` and
-  ``EncryptOptions.getStringOptions()`` methods replace the deprecated
-  ``TextOptions`` class and its ``textOptions()`` and
-  ``getTextOptions()`` methods. To perform a QE string query, set the
-  encryption algorithm to ``"String"``.
+  ``Text`` to ``String``. To perform a QE string query, make the
+  following changes:
+
+  - Use the ``StringOptions`` class instead of ``TextOptions``.
+  - Use the ``EncryptOptions.stringOptions()`` method instead of
+    ``textOptions()``.
+  - Use the ``EncryptOptions.getStringOptions()`` method instead of
+    ``getTextOptions()``.
+  - Set the encryption algorithm to ``"String"``.
 
 - Upgrades the ``libmongocrypt`` version to 1.20.0.

--- a/dbx/jvm/v5.9-wn-items.rst
+++ b/dbx/jvm/v5.9-wn-items.rst
@@ -1,12 +1,13 @@
-- Promotes Queryable Encryption (QE) prefix, suffix, and substring queries
-  to general availability (GA). These query types are supported on MongoDB
-  9.0 and later. To learn more about QE, see |encrypt-link|.
+- Promotes Queryable Encryption (QE) prefix, suffix, and substring
+  queries to general availability (GA). These query types are supported
+  on MongoDB 9.0 and later. To learn more about QE, see |encrypt-link|.
 
-- Renames the explicit encryption API for QE string queries from ``Text`` to
-  ``String``. Use the ``StringOptions`` class and the
+- Renames the explicit encryption API for QE string queries from
+  ``Text`` to ``String``. The new ``StringOptions`` class and the
   ``EncryptOptions.stringOptions()`` and
-  ``EncryptOptions.getStringOptions()`` methods, and set the encryption
-  algorithm to ``"String"``. The ``TextOptions`` class and the
-  ``textOptions()`` and ``getTextOptions()`` methods are deprecated.
+  ``EncryptOptions.getStringOptions()`` methods replace the deprecated
+  ``TextOptions`` class and its ``textOptions()`` and
+  ``getTextOptions()`` methods. To perform a QE string query, set the
+  encryption algorithm to ``"String"``.
 
 - Upgrades the ``libmongocrypt`` version to 1.20.0.

--- a/dbx/jvm/v5.9-wn-items.rst
+++ b/dbx/jvm/v5.9-wn-items.rst
@@ -1,0 +1,12 @@
+- Promotes Queryable Encryption (QE) prefix, suffix, and substring queries
+  to general availability (GA). These query types are supported on MongoDB
+  9.0 and later. To learn more about QE, see |encrypt-link|.
+
+- Renames the explicit encryption API for QE string queries from ``Text`` to
+  ``String``. Use the ``StringOptions`` class and the
+  ``EncryptOptions.stringOptions()`` and
+  ``EncryptOptions.getStringOptions()`` methods, and set the encryption
+  algorithm to ``"String"``. The ``TextOptions`` class and the
+  ``textOptions()`` and ``getTextOptions()`` methods are deprecated.
+
+- Upgrades the ``libmongocrypt`` version to 1.20.0.


### PR DESCRIPTION
## Summary

Adds the shared JVM `v5.9-wn-items.rst` for the mongo-java-driver 5.9.0 release, consumed via `sharedinclude` by the Java, Java Reactive Streams, Kotlin Coroutine, Kotlin Sync, and Scala driver release notes.

Content (5.8.0 → 5.9.0 delta):
- Queryable Encryption prefix/suffix/substring queries promoted to GA (server 9.0+)
- Explicit encryption API renamed `Text` → `String` (`TextOptions` deprecated)
- libmongocrypt upgraded to 1.20.0

## Related
- Companion docs PR in `10gen/docs-mongodb-internal` (JVM 5.9 version update)

JIRA: https://jira.mongodb.org/browse/DOCSP-61752