### PR TITLE
DOCSP-60382 Add shared Let's Encrypt OCSP deprecation note

### DIFF
--- a/server/lets-encrypt-ocsp-note.rst
+++ b/server/lets-encrypt-ocsp-note.rst
@@ -2,8 +2,8 @@
 
    `Let's Encrypt has ended OCSP support
    <https://letsencrypt.org/2024/12/05/ending-ocsp/>`__ for newer
-   certificates. As a result, certificates issued by Let's Encrypt
+   certificates. As a result, new certificates issued by Let's Encrypt
    might not include an OCSP responder URL. OCSP revocation checking
    occurs only when a certificate contains an OCSP URI, so a missing
-   OCSP URL is expected and doesn't by itself indicate a problem with
+   OCSP URL is expected and doesn't necessarily indicate a problem with
    your MongoDB deployment.

--- a/server/lets-encrypt-ocsp-note.rst
+++ b/server/lets-encrypt-ocsp-note.rst
@@ -2,7 +2,7 @@
 
    `Let's Encrypt has ended OCSP support
    <https://letsencrypt.org/2024/12/05/ending-ocsp/>`__ for newer
-   certificates. As a result, new certificates issued by Let's Encrypt
+   certificates. New certificates issued by Let's Encrypt
    might not include an OCSP responder URL. OCSP revocation checking
    occurs only when a certificate contains an OCSP URI, so a missing
    OCSP URL is expected and doesn't necessarily indicate a problem with

--- a/server/lets-encrypt-ocsp-note.rst
+++ b/server/lets-encrypt-ocsp-note.rst
@@ -1,0 +1,9 @@
+.. note:: Let's Encrypt OCSP Deprecation
+
+   `Let's Encrypt has ended OCSP support
+   <https://letsencrypt.org/2024/12/05/ending-ocsp/>`__ for newer
+   certificates. As a result, certificates issued by Let's Encrypt
+   might not include an OCSP responder URL. OCSP revocation checking
+   occurs only when a certificate contains an OCSP URI, so a missing
+   OCSP URL is expected and doesn't by itself indicate a problem with
+   your MongoDB deployment.


### PR DESCRIPTION
## Summary

Adds a shared include, `server/lets-encrypt-ocsp-note.rst`, that explains that Let's Encrypt has ended OCSP support and that newer Let's Encrypt certificates might not include an OCSP responder URL — expected behavior that does not by itself indicate a MongoDB/Atlas misconfiguration.

This shared note is referenced via `.. sharedinclude:: server/lets-encrypt-ocsp-note.rst` from the 11 driver TLS pages in docs-mongodb-internal (DOCSP-60382). It must merge before the consuming PR's staging/build can resolve the include.

## JIRA

https://jira.mongodb.org/browse/DOCSP-60382