### PR TITLE
DOCSP-61608: Add shared JSON-to-BSON injection warning admonition

### DIFF
--- a/dbx/json-bson-injection-warning.rst
+++ b/dbx/json-bson-injection-warning.rst
@@ -1,0 +1,14 @@
+.. warning:: Validate Untrusted Input Before Converting JSON to BSON
+
+   If you convert a JSON string to BSON and then use the result in a
+   query, update, or command, an attacker can inject operators or
+   unexpected field values that change the meaning of the operation.
+   This risk is greatest when the JSON originates from a user, an
+   API request, or another untrusted source.
+
+   To learn more about how to reduce this risk, see
+   :ref:`client-libraries-security-best-practices`.
+
+.. TODO: DOCSP-61609 must define a page with the label
+   client-libraries-security-best-practices before this ref resolves.
+   Update the label here if DOCSP-61609 ships with a different one.


### PR DESCRIPTION
## Summary
- Adds a new shared admonition (`dbx/json-bson-injection-warning.rst`) warning developers that converting untrusted JSON to BSON and using it in a query/update/command can enable injection attacks.
- Part of DOCSP-61601 (audit JSON-to-BSON security advisory). This ticket (DOCSP-61608) is scoped to writing the admonition text only.

## Notes
- The admonition links to `:ref:`client-libraries-security-best-practices``, which will be defined by DOCSP-61609 ("Write page for Client Libraries that covers security best practices"). That page doesn't exist yet, so this ref won't resolve until it ships. Left an RST TODO comment in the file flagging this.
- Wiring this admonition into individual driver pages via `sharedinclude` is DOCSP-61610, not part of this PR.

## Test plan
- [x] Ran `./lint-docs.sh vale` against the new file — 0 errors, 0 warnings.
- [ ] `:ref:` target added once DOCSP-61609 lands (follow-up).

Jira: https://jira.mongodb.org/browse/DOCSP-61608