### PR TITLE
DOCSP-61609: Rename client-libraries-security-best-practices ref to client-libraries-best-practices

### DIFF
--- a/dbx/json-bson-injection-warning.rst
+++ b/dbx/json-bson-injection-warning.rst
@@ -7,8 +7,4 @@
    API request, or another untrusted source.
 
    To learn more about validating input before conversion, see
-   :ref:`client-libraries-security-best-practices`.
-
-.. TODO: DOCSP-61609 must define a page with the label
-   client-libraries-security-best-practices before this ref resolves.
-   Update the label here if DOCSP-61609 ships with a different one.
+   :ref:`client-libraries-best-practices`.


### PR DESCRIPTION
## Summary
- DOCSP-61609 ("Write page for Client Libraries that covers security best practices") shipped as a general client library best practices page rather than a security-only page, so this renames the target ref from `client-libraries-security-best-practices` to `client-libraries-best-practices` to match.
- Removes the `.. TODO::` comment, since the target page now exists with the new label.

## Notes
- Depends on the corresponding page/label rename in `docs-mongodb-internal` (`content/drivers/source/client-libraries-best-practices.txt`, label `client-libraries-best-practices`), landing as part of DOCSP-61609.
- No change to the admonition's warning text or link sentence, only the ref target.

Jira: https://jira.mongodb.org/browse/DOCSP-61609