### PR TITLE
DOCSP-62272: Add JVM v5.9.1 shared release notes items

### DIFF
--- a/dbx/jvm/v5.9.1-wn-items.rst
+++ b/dbx/jvm/v5.9.1-wn-items.rst
@@ -1,0 +1,2 @@
+- Fixes an issue where the driver did not correctly resolve forwarded
+  type arguments across POJO class hierarchy edges.


### PR DESCRIPTION
## Description

Adds the shared JVM release notes items file for the v5.9.1 patch release, referenced via `sharedinclude` by the JVM driver docsets.

Companion PR in docs-mongodb-internal for the Java driver.

JIRA: https://jira.mongodb.org/browse/DOCSP-62272