### PR TITLE
DOCSP-61609: Point json-bson-injection-warning at the specific section anchor

### DIFF
--- a/dbx/json-bson-injection-warning.rst
+++ b/dbx/json-bson-injection-warning.rst
@@ -7,4 +7,4 @@
    API request, or another untrusted source.
 
    To learn more about validating input before conversion, see
-   :ref:`client-libraries-best-practices`.
+   :ref:`best-practices-validate-json-bson-input`.


### PR DESCRIPTION
## Summary
The Client Libraries Best Practices page (10gen/docs-mongodb-internal#22308) added a dedicated anchor for its "Validate Untrusted Input Before Converting JSON to BSON" section: `best-practices-validate-json-bson-input`. This updates the shared admonition's ref to point directly at that section instead of the top of the page.

Follow-up to #178.