### PR TITLE
DOCSP-57078 Update server version for IWM rate limiting to v9.0

### DIFF
--- a/dbx/adaptive-rate-limiting.rst
+++ b/dbx/adaptive-rate-limiting.rst
@@ -1,21 +1,21 @@
 .. note:: Adaptive Rate Limiting
 
    If errors with ``SystemOverloadedError`` or ``RetryableError`` labels are causing
-   failures in your application or appearing in your application logs, your
-   driver may not be upgraded to a version that supports adaptive rate limiting.
-   We recommend upgrading your |driver-name| to version |ivm-compatible-version|
-   or later. If you continue to see these errors after upgrading, you can
-   address them through server-side changes, such as reviewing your
-   Intelligent Workload Management (IWM) configuration, or through
-   application-side changes, such as implementing custom error handling or
-   client-side request throttling. Depending on your situation,
-   application-side changes may be preferable or necessary.
+   failures in your application or appearing in your application logs, Overload
+   Protection may be active on your cluster and your driver may not be upgraded to
+   a version that supports it. We recommend upgrading your |driver-name| to
+   version |ivm-compatible-version| or later. If you continue to see these
+   errors after upgrading, you can address them through server-side changes,
+   such as reviewing your Overload Protection configuration,
+   or through application-side changes, such as implementing custom error
+   handling or client-side request throttling. Depending on your situation,
+   application-side changes may be preferable or necessary. 
 
-   Overload Protection helps manage server load by rejecting or terminating
-   excess work during sustained overload. This feature is available on MongoDB
-   9.0 and later.
+   Overload Protection is a feature of Intelligent Workload Management (IWM),
+   and helps manage server load by rejecting or terminating excess work during
+   sustained overload. This feature is available on MongoDB 9.0 and later.
    
-   For more information about IWM, see the :atlas:`Intelligent Workload
+   For more information about IWM or Overload Protection, see the :atlas:`Intelligent Workload
    Management </intelligent-workload-management/>` page or :atlas:`Overload
    Errors </overload-errors/?interface=driver&language=|language|>` page in the
    Atlas documentation.

--- a/dbx/adaptive-rate-limiting.rst
+++ b/dbx/adaptive-rate-limiting.rst
@@ -13,7 +13,7 @@
 
    Adaptive rate limiting helps manage server load by dynamically adjusting
    request rates based on current conditions. This feature is available on
-   MongoDB 8.3 and later.
+   MongoDB 9.0 and later.
 
    For more information about IWM, see the :atlas:`Reliability, Availability,
    and Workload Management </intelligent-workload-management/>` page or

--- a/dbx/adaptive-rate-limiting.rst
+++ b/dbx/adaptive-rate-limiting.rst
@@ -11,9 +11,9 @@
    client-side request throttling. Depending on your situation,
    application-side changes may be preferable or necessary.
 
-   Adaptive rate limiting helps manage server load by dynamically adjusting
-   request rates based on current conditions. This feature is available on
-   MongoDB 9.0 and later.
+   Overload Protection helps manage server load by rejecting or terminating
+   excess work during sustained overload. This feature is available on MongoDB
+   9.0 and later.
    
    For more information about IWM, see the :atlas:`Intelligent Workload
    Management </intelligent-workload-management/>` page or :atlas:`Overload

--- a/dbx/adaptive-rate-limiting.rst
+++ b/dbx/adaptive-rate-limiting.rst
@@ -15,7 +15,7 @@
    and helps manage server load by rejecting or terminating excess work during
    sustained overload. This feature is available on MongoDB 9.0 and later.
    
-   For more information about IWM or Overload Protection, see the :atlas:`Intelligent Workload
+   For more information about IWM or handling overload errors, see the :atlas:`Intelligent Workload
    Management </intelligent-workload-management/>` page or :atlas:`Overload
    Errors </overload-errors/?interface=driver&language=|language|>` page in the
    Atlas documentation.

--- a/dbx/adaptive-rate-limiting.rst
+++ b/dbx/adaptive-rate-limiting.rst
@@ -14,9 +14,8 @@
    Adaptive rate limiting helps manage server load by dynamically adjusting
    request rates based on current conditions. This feature is available on
    MongoDB 9.0 and later.
-
-   For more information about IWM, see the :atlas:`Reliability, Availability,
-   and Workload Management </intelligent-workload-management/>` page or
-   :atlas:`Overload Errors
-   </overload-errors/?interface=driver&language=|language|>` page in the Atlas
-   documentation.
+   
+   For more information about IWM, see the :atlas:`Intelligent Workload
+   Management </intelligent-workload-management/>` page or :atlas:`Overload
+   Errors </overload-errors/?interface=driver&language=|language|>` page in the
+   Atlas documentation.


### PR DESCRIPTION
Supports: https://github.com/10gen/docs-mongodb-internal/pull/22085

Updates the server version number.

Please confirm the production links as well.