### PR TITLE
DOCSP-63277: Add JVM driver v5.10.0 What's New items

### DIFF
--- a/dbx/jvm/v5.10.0-wn-items.rst
+++ b/dbx/jvm/v5.10.0-wn-items.rst
@@ -6,6 +6,6 @@
   Use this API to configure score normalization, weighting, and
   score details. This feature requires MongoDB 8.2 or later.
 
-- Adds support for nested embeddings and arrays of embeddings in
-  ``$vectorSearch`` queries through the ``parentFilter`` and
-  ``nestedOptions`` options.
+- Adds the ``parentFilter`` and ``nestedOptions`` options, which
+   allow nested embeddings and arrays of embeddings in
+  ``$vectorSearch`` queries. 

--- a/dbx/jvm/v5.10.0-wn-items.rst
+++ b/dbx/jvm/v5.10.0-wn-items.rst
@@ -1,0 +1,11 @@
+- Adds the ``$scoreFusion`` aggregation stage, which combines and
+  normalizes the scores of multiple search pipelines. This stage
+  requires MongoDB 8.2 or later.
+
+- Adds a fluent builder API for the ``$score`` aggregation stage.
+  Use this API to configure score normalization, weighting, and
+  score details. This feature requires MongoDB 8.2 or later.
+
+- Adds support for nested embeddings and arrays of embeddings in
+  ``$vectorSearch`` queries through the ``parentFilter`` and
+  ``nestedOptions`` options.


### PR DESCRIPTION
## Description

Adds the shared release note items for the mongo-java-driver r5.10.0 release, consumed via `sharedinclude` by the Java Sync, Java Reactive Streams, Kotlin Sync, Kotlin Coroutine, and Scala driver docs:

- Adds the `$scoreFusion` aggregation stage (MongoDB 8.2+)
- Adds a fluent builder API for the `$score` aggregation stage (MongoDB 8.2+)
- Adds `$vectorSearch` support for nested embeddings and arrays of embeddings via `parentFilter` and `nestedOptions`

Driver-specific items (the `@Beta` removal for Java/Scala, and the Kotlin `ByteArray` BSON encoding fix) are documented directly in each driver's release notes in `docs-mongodb-internal`, not in this shared file.

## Jira

https://jira.mongodb.org/browse/DOCSP-63277

🤖 Generated with [Claude Code](https://claude.com/claude-code)