### PR TITLE
Fix indentation in v5.10.0-wn-items.rst

### DIFF
--- a/dbx/jvm/v5.10.0-wn-items.rst
+++ b/dbx/jvm/v5.10.0-wn-items.rst
@@ -7,5 +7,5 @@
   score details. This feature requires MongoDB 8.2 or later.
 
 - Adds the ``parentFilter`` and ``nestedOptions`` options, which
-   allow nested embeddings and arrays of embeddings in
-  ``$vectorSearch`` queries. 
+  allow nested embeddings and arrays of embeddings in
+  ``$vectorSearch`` queries.


### PR DESCRIPTION
Fixes a 3-space indent (should be 2) on a bullet continuation line, introduced during review on #184.

🤖 Generated with [Claude Code](https://claude.com/claude-code)